### PR TITLE
Pass user token as a header vaalue for each request to backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 coverage
 dist
 src/client/model
+src/server/model/validation-strategy.ts

--- a/package.json
+++ b/package.json
@@ -46,19 +46,20 @@
     },
     "watch": {
         "_copyJson": "src/server/config.json",
-        "map": "dist/**/*.js"
+        "_generateImportMap": "dist/client/**/*.js"
     },
     "scripts": {
-        "map": "nodejs-base-server -c dist/server/config.json -M",
         "clean": "rm -rf node_modules dist package-lock.json",
         "_shareModelDefs": "mkdir dist; mkdir dist/server; pushd ./src/client; ln -s ../server/model/ .; popd",
+        "_linkComponentBaseDependency": "pushd src/server/model; ln -s ../../../node_modules/@hmh/component-base/src/mixins/validation-strategy.ts .; popd",
         "_copyJson": "cp ./src/server/config.json ./dist/server",
+        "_generateImportMap": "nodejs-base-server -c dist/server/config.json -M",
         "_firstCompilation": "tsc -p ./src/server; tsc -p ./src/client; tsc -p ./src/server-unit; tsc -p ./src/client-unit",
+        "_sass": "node-sass src/client/sass -r -o dist/client/css",
         "init": "npm run _shareModelDefs; npm run _copyJson; npm run _firstCompilation; npm run sass",
-        "watch": "npm run init; concurrently --names 'server,client,s-unit, json , sass ' -c 'bgBlue,black.bgGreen,black.bgYellow,bgRed,bgMagenta,bgCyan,yellow.bgBlack' 'tsc -p ./src/server --watch' 'tsc -p ./src/client --watch' 'tsc -p ./src/server-unit --watch' 'npm run sass -- -w' 'npm-watch'",
+        "watch": "npm run init; concurrently --names 'server,client,s-unit, json , sass ' -c 'bgBlue,black.bgGreen,black.bgYellow,bgRed,bgMagenta,bgCyan,yellow.bgBlack' 'tsc -p ./src/server --watch' 'tsc -p ./src/client --watch' 'tsc -p ./src/server-unit --watch' 'npm run _sass -- -w' 'npm-watch'",
         "dev": "nodemon -r source-map-support/register dist/server/server.js --watch ./dist/server",
         "debug": "nodemon --inspect -r source-map-support/register dist/server/server.js --watch ./dist/server",
-        "sass": "node-sass src/client/sass -r -o dist/client/css",
         "start": "node dist/server/server.js",
         "test": "intern config=src/server-unit/intern.json",
         "test-polymer": "polymer test -l chrome -p",

--- a/src/client/app/comm.ts
+++ b/src/client/app/comm.ts
@@ -1,8 +1,13 @@
 import { Problem } from '../model/Problem';
 import { ProblemResponse } from '../model/ProblemResponse';
 
+function getUserId(): string {
+    const inputField: HTMLElement = document.getElementById('hmhUserId');
+    return (inputField as HTMLInputElement).value || '12345';
+}
+
 export async function loadProblem(id: string): Promise<Problem> {
-    return fetch('/api/v1/ang-eng/Problem/' + id, { headers: { accept: 'application/json' }, method: 'GET' })
+    return fetch('/api/v1/ang-eng/Problem/' + id, { headers: { accept: 'application/json', 'X-HMH-User-Id': getUserId() }, method: 'GET' })
         .then((response: Response): any => response.json())
         .then(
             (model: any): Problem => {
@@ -14,7 +19,7 @@ export async function loadProblem(id: string): Promise<Problem> {
 export async function evaluateProblemResponse(model: ProblemResponse): Promise<string> {
     return fetch('/api/v1/ang-eng/ProblemResponse', {
         body: JSON.stringify(model.toHttp()),
-        headers: { accept: 'application/json', 'content-type': 'application/json', 'x-hmh-userId': '12345-678-90' },
+        headers: { accept: 'application/json', 'content-type': 'application/json', 'X-HMH-User-Id': getUserId() },
         method: 'POST'
     }).then(
         (response: Response): string => {

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -9,9 +9,18 @@
 
     <link rel="icon" href="/images/hmhco.com.png">
     <link rel="stylesheet" href="/css/fonts.css">
+    <style>
+        #hmhUserId {
+            width: calc(100% - 10em);
+        }
+    </style>
 </head>
 
 <body>
+    <fieldset>
+        <legend>Logged user token</legend>
+        <label>HMH User Id: <input id="hmhUserId"/></label>
+    </fieldset>
     <h1>Assessment Engine</h1>
 
     <ul id="hooks"></ul>

--- a/src/server/config.json
+++ b/src/server/config.json
@@ -10,6 +10,10 @@
             },
             "defaultClientContentPath": "../../src/client/index.html",
             "port": 8686,
+            "requestMetadata": {
+                "headers": ["X-Sort", "X-Ids-Only", "X-HMH-User-Id"],
+                "cookies": []
+            },
             "staticContentMaxAge": 0,
             "staticFolderMapping": {
                 "/css": "../../dist/client/css",
@@ -39,6 +43,10 @@
             },
             "defaultClientContentPath": "../../src/client/index.html",
             "port": 8686,
+            "requestMetadata": {
+                "headers": ["X-Sort", "X-Ids-Only", "X-HMH-User-Id"],
+                "cookies": []
+            },
             "staticContentMaxAge": 3000000,
             "staticFolderMapping": {
                 "/css": "../../dist/client/css",

--- a/src/server/exceptions/NotAuthorizedException.ts
+++ b/src/server/exceptions/NotAuthorizedException.ts
@@ -1,0 +1,13 @@
+import { BaseException } from '@hmh/nodejs-base-server';
+
+export class NotAuthorizedException extends BaseException {
+    public constructor(message: string) {
+        super(message);
+        this.errorCode = 401;
+
+        // Maintains proper stack trace for where our error was thrown (only available on V8)
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, NotAuthorizedException);
+        }
+    }
+}

--- a/src/server/model/ResponseValidation.ts
+++ b/src/server/model/ResponseValidation.ts
@@ -1,19 +1,7 @@
+import { FeedbackType, Strategy } from './validation-strategy';
+export { FeedbackType, matchers, Strategy } from './validation-strategy';
+
 import { BaseModel } from './BaseModel';
-
-export enum Strategy {
-    ANY = 'any',
-    CONTAINS = 'contains',
-    EXACT_MATCH = 'exactMatch',
-    EXACT_ORDER = 'exactOrder',
-    FUZZY_MATCH = 'fuzzyMatch',
-    MATH_EQUIVALENT = 'mathEquivalent'
-}
-
-export enum FeedbackType {
-    POSITIVE = 'positive',
-    NEGATIVE = 'negative',
-    NEUTRAL = 'neutral'
-}
 
 export class ResponseValidation extends BaseModel {
     // Factory method

--- a/src/server/service/BaseService.ts
+++ b/src/server/service/BaseService.ts
@@ -1,0 +1,56 @@
+import { BaseDao as DAO, BaseService as Service } from '@hmh/nodejs-base-server';
+import { NotAuthorizedException } from '../exceptions/NotAuthorizedException';
+import { BaseModel as Model } from '../model/BaseModel';
+
+export class BaseService<T extends DAO<Model>> extends Service<T> {
+    public static readonly LOGGED_USER_KEY = 'X-HMH-User-Id';
+
+    protected constructor(dao: T) {
+        super(dao);
+    }
+
+    public async select(params: { [key: string]: any }, metadata?: { [key: string]: string }): Promise<Model[]> {
+        if (!metadata && !metadata[BaseService.LOGGED_USER_KEY]) {
+            throw new NotAuthorizedException('Missing authorization token');
+        }
+        return this.dao.query(params);
+    }
+
+    public async get(id: string, parameters?: { [key: string]: any }, metadata?: { [key: string]: string }): Promise<Model> {
+        if (!metadata && !metadata[BaseService.LOGGED_USER_KEY]) {
+            throw new NotAuthorizedException('Missing authorization token');
+        }
+        return this.dao.get(id, parameters);
+    }
+
+    public async create(candidate: Model, metadata?: { [key: string]: string }): Promise<string> {
+        if (!metadata && !metadata[BaseService.LOGGED_USER_KEY]) {
+            throw new NotAuthorizedException('Missing authorization token');
+        }
+        candidate.authorId = metadata[BaseService.LOGGED_USER_KEY]; // To keep track of the owner
+        return this.dao.create(candidate);
+    }
+
+    public async update(id: string, candidate: Model, metadata?: { [key: string]: string }): Promise<string> {
+        if (!metadata && !metadata[BaseService.LOGGED_USER_KEY]) {
+            throw new NotAuthorizedException('Missing authorization token');
+        }
+        const model: Model = await this.dao.get(id);
+        if (model.authorId !== metadata[BaseService.LOGGED_USER_KEY]) {
+            throw new NotAuthorizedException('Only the author can update the entity');
+        }
+        delete candidate.authorId; // To prevent changing the owner
+        return this.dao.update(id, candidate);
+    }
+
+    public async delete(id: string, metadata?: { [key: string]: string }): Promise<void> {
+        if (!metadata && !metadata[BaseService.LOGGED_USER_KEY]) {
+            throw new NotAuthorizedException('Missing authorization token');
+        }
+        const model: Model = await this.dao.get(id);
+        if (model.authorId !== metadata[BaseService.LOGGED_USER_KEY]) {
+            throw new NotAuthorizedException('Only the author can delete the entity');
+        }
+        return this.dao.delete(id);
+    }
+}

--- a/src/server/service/ProblemResponseService.ts
+++ b/src/server/service/ProblemResponseService.ts
@@ -1,13 +1,12 @@
-import { BaseService } from '@hmh/nodejs-base-server';
 import { ProblemDao as AssociatedDAO } from '../dao/ProblemDao';
 import { ProblemResponseDao as DAO } from '../dao/ProblemResponseDao';
 import { Problem } from '../model/Problem';
 import { ProblemResponse as Model } from '../model/ProblemResponse';
-import { FeedbackType, ResponseValidation, Strategy } from '../model/ResponseValidation';
-import { matchers } from './ResponseValidationStrategy';
+import { FeedbackType, matchers, ResponseValidation, Strategy } from '../model/ResponseValidation';
+import { injectVariables } from '../model/VariableHelpers';
+import { BaseService } from './BaseService';
 
 import { JSDOM } from 'jsdom';
-import { injectVariables } from '../model/VariableHelpers';
 
 export class ProblemResponseService extends BaseService<DAO> {
     public static getInstance(): ProblemResponseService {
@@ -26,7 +25,7 @@ export class ProblemResponseService extends BaseService<DAO> {
     }
 
     /* istanbul ignore next */
-    public async create(candidate: Model): Promise<string> {
+    public async create(candidate: Model, metadata?: { [key: string]: string }): Promise<string> {
         const problem: Problem = await this.associatedDao.get(candidate.problemId);
         const template: DocumentFragment = JSDOM.fragment(injectVariables(problem.template[0], candidate.variables));
         // FIXME: Address all problem steps, not just the first one...
@@ -66,8 +65,8 @@ export class ProblemResponseService extends BaseService<DAO> {
         candidate.evaluations = evaluations;
         candidate.feedbackType = feedbackType;
         candidate.score = feedbackType === FeedbackType.NEGATIVE ? negativeScore : totalScore;
-        // return super.create(candidate);
 
+        // return super.create(candidate, metadata);
         return '111-' + problem.id; // FIXME: temporary shortcut while information about the author (a request header) is conveyed out by the base server logic...
     }
 

--- a/src/server/service/ProblemService.ts
+++ b/src/server/service/ProblemService.ts
@@ -1,6 +1,6 @@
-import { BaseService } from '@hmh/nodejs-base-server';
 import { ProblemDao as DAO } from '../dao/ProblemDao';
 import { Problem as Model } from '../model/Problem';
+import { BaseService } from './BaseService';
 
 export class ProblemService extends BaseService<DAO> {
     public static getInstance(): ProblemService {
@@ -16,8 +16,8 @@ export class ProblemService extends BaseService<DAO> {
         super(DAO.getInstance());
     }
 
-    public async get(id: string, parameters: { [key: string]: string } = {}): Promise<Model> {
-        return super.get(id, parameters).then((entity: Model): Model => filterOut(entity, parameters));
+    public async get(id: string, parameters: { [key: string]: string } = {}, metadata: { [key: string]: string }): Promise<Model> {
+        return super.get(id, parameters, metadata).then((entity: Model): Model => filterOut(entity, parameters));
     }
 }
 


### PR DESCRIPTION
Use strategy code from @hmh/compoment-base/mixins
Re-export definitions from mixins in model/ResponseValidation to minimize dependencies